### PR TITLE
Fixes wrong end date ind graph

### DIFF
--- a/src/config/configs.js
+++ b/src/config/configs.js
@@ -1,5 +1,5 @@
 export default {
-  SERVICE_URL : '/tags-service/smurf/netarchive/text',
-  START_YEAR : 1998,
-  END_YEAR: 2021
+  SERVICE_URL: '/tags-service/smurf/netarchive/text',
+  START_YEAR: 1998,
+  END_YEAR: (new Date().getFullYear() + 1).toString()
 }


### PR DESCRIPTION
Fixes wrong end date ind graph and for some yet unknown reason you have to +1 the year to get the current year as the last label.